### PR TITLE
FIX: title positioning should be centered

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -75,13 +75,9 @@
 
   &.--blog-image-above-title {
     #topic-title {
-      justify-content: left;
+      justify-content: center;
       margin-top: var(--space-4);
       margin-inline: auto;
-
-      .title-wrapper {
-        width: auto;
-      }
 
       @include viewport.until(sm) {
         margin-bottom: 0;


### PR DESCRIPTION
This ensures the width and positioning aligns with the post contents.

**Before**:

<img width="500" alt="Screenshot 2026-02-11 at 6 09 04 PM" src="https://github.com/user-attachments/assets/a4e9d2da-2696-41ed-913e-7c905e6df760" />

**After**:

<img width="500"  alt="Screenshot 2026-02-11 at 6 08 43 PM" src="https://github.com/user-attachments/assets/36a8e353-080d-482a-833a-22d7ac3b1cbc" />
