### PR TITLE
FIX: handle missing first paragraph in drop cap logic

### DIFF
--- a/javascripts/discourse/api-initializers/blog-post-styling.js
+++ b/javascripts/discourse/api-initializers/blog-post-styling.js
@@ -17,6 +17,10 @@ function wrapFirstLetter(firstPost) {
   const firstParagraph = Array.from(firstPost.querySelectorAll("p")).find(
     (p) => p.textContent.trim().length > 0
   );
+
+  if (!firstParagraph) {
+    return;
+  }
   firstParagraph.innerHTML = firstParagraph.innerHTML.replace(
     /(^|>)([\p{L}\p{N}])/u,
     "$1<span class='blog-post__drop-cap'>$2</span>"

--- a/spec/system/blog_features_spec.rb
+++ b/spec/system/blog_features_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Blog post features", system: true do
   fab!(:tag) { Fabricate(:tag, name: "blog") }
   fab!(:image_upload) { Fabricate(:image_upload, width: 1000, height: 1000) }
   fab!(:topic) { Fabricate(:topic, tags: [tag], image_upload_id: image_upload.id) }
-  fab!(:user)
+  fab!(:admin)
 
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let!(:theme) { upload_theme_component }
@@ -13,7 +13,7 @@ RSpec.describe "Blog post features", system: true do
     theme.update_setting(:blog_tag, "blog")
     theme.update_setting(:image_position, "below title")
     theme.save!
-    sign_in(user)
+    sign_in(admin)
   end
 
   describe "drop cap (wrap first letter)" do
@@ -25,6 +25,15 @@ RSpec.describe "Blog post features", system: true do
 
       topic_page.visit_topic(topic)
       expect(page).to have_css(".blog-post__drop-cap")
+    end
+
+    it "does not error when there is no paragraph" do
+      theme.update_setting(:dropcap_enabled, true)
+      theme.save!
+      post.update!(raw: "[summary]just summary block[/summary]")
+
+      topic_page.visit_topic(topic)
+      expect(page).not_to have_css(".broken-theme-alert-banner")
     end
 
     it "does not wrap first letter when dropcap is disabled" do


### PR DESCRIPTION
Posts that contain only block-level elements (e.g., `[summary]`) and no `<p>` tags would cause an error in `wrapFirstLetter` when trying to access `innerHTML` on `undefined`. This PR adds an early return guard and a corresponding system test.