### PR TITLE
UX: Move on from comma-separated category slugs and use the category selector

### DIFF
--- a/javascripts/discourse/lib/is-blog-topic.js
+++ b/javascripts/discourse/lib/is-blog-topic.js
@@ -1,5 +1,3 @@
-import Category from "discourse/models/category";
-
 export default function isBlogTopic(topic, settings) {
   if (!topic) {
     return false;
@@ -10,18 +8,10 @@ export default function isBlogTopic(topic, settings) {
 
   if (topic.category_id) {
     const allowedCategories = settings.blog_category
-      .split(",")
-      .map((c) => c.trim())
-      .filter(Boolean);
-    const currentCategory = Category.findById(topic.category_id);
-    if (currentCategory) {
-      const parentCategorySlug = currentCategory.parentCategory
-        ? `${currentCategory.parentCategory.slug}-`
-        : "";
-      hasCategory = allowedCategories.some(
-        (c) => c === `${parentCategorySlug}${currentCategory.slug}`
-      );
-    }
+      .split("|")
+      .filter(Boolean)
+      .map(Number);
+    hasCategory = allowedCategories.includes(topic.category_id);
   }
 
   if (topic.tags) {

--- a/migrations/settings/0001-migrate-blog-category-to-ids.js
+++ b/migrations/settings/0001-migrate-blog-category-to-ids.js
@@ -1,0 +1,16 @@
+export default function migrate(settings, helpers) {
+  if (settings.has("blog_category")) {
+    const oldValue = settings.get("blog_category");
+    if (oldValue) {
+      const slugs = oldValue
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      const ids = slugs
+        .map((slug) => helpers.getCategoryIdBySlug(slug))
+        .filter(Boolean);
+      settings.set("blog_category", ids.join("|"));
+    }
+  }
+  return settings;
+}

--- a/settings.yml
+++ b/settings.yml
@@ -1,14 +1,9 @@
 blog_category:
-  type: string
+  type: list
+  list_type: category
   default: ""
   description:
-    en: "Enter the category slug of your blog category as it appears in the url.
-      The slug is bold in the following example url:
-      https://community.example.org/c/<b>blog-posts</b>/3
-      <br><br>
-      Note: you may use more than one category slug by comma separating the
-      slug values like: <b>blog-one,blog-two</b> <br>
-      Be sure there are no spaces after the commas."
+    en: "Topics will have blog styling applied when they are in any of the categories included in this setting."
 blog_tag:
   type: list
   list_type: tag

--- a/spec/system/blog_category_spec.rb
+++ b/spec/system/blog_category_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe "Blog styling with categories", system: true do
+  fab!(:category)
+  fab!(:image_upload) { Fabricate(:image_upload, width: 1000, height: 1000) }
+  fab!(:topic) { Fabricate(:topic, category:, image_upload_id: image_upload.id) }
+  fab!(:post) { Fabricate(:post, topic:) }
+  fab!(:user)
+
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+  let!(:theme) { upload_theme_component }
+
+  before do
+    theme.update_setting(:blog_category, category.id.to_s)
+    theme.update_setting(:image_position, "below title")
+    theme.save!
+    sign_in(user)
+  end
+
+  it "displays blog styling when topic is in a matching category" do
+    topic_page.visit_topic(topic)
+    expect(page).to have_css(".blog-image-container")
+  end
+
+  it "does not display blog styling when topic is in a different category" do
+    other_category = Fabricate(:category)
+    other_topic = Fabricate(:topic, category: other_category, image_upload_id: image_upload.id)
+    Fabricate(:post, topic: other_topic)
+
+    topic_page.visit_topic(other_topic)
+    expect(page).to have_no_css(".blog-image-container")
+  end
+
+  it "supports multiple categories" do
+    second_category = Fabricate(:category)
+    second_topic =
+      Fabricate(:topic, category: second_category, image_upload_id: image_upload.id)
+    Fabricate(:post, topic: second_topic)
+
+    theme.update_setting(:blog_category, "#{category.id}|#{second_category.id}")
+    theme.save!
+
+    topic_page.visit_topic(second_topic)
+    expect(page).to have_css(".blog-image-container")
+  end
+end

--- a/spec/system/blog_category_spec.rb
+++ b/spec/system/blog_category_spec.rb
@@ -33,8 +33,7 @@ RSpec.describe "Blog styling with categories", system: true do
 
   it "supports multiple categories" do
     second_category = Fabricate(:category)
-    second_topic =
-      Fabricate(:topic, category: second_category, image_upload_id: image_upload.id)
+    second_topic = Fabricate(:topic, category: second_category, image_upload_id: image_upload.id)
     Fabricate(:post, topic: second_topic)
 
     theme.update_setting(:blog_category, "#{category.id}|#{second_category.id}")

--- a/test/unit/migrations/settings/0001-migrate-blog-category-to-ids-test.js
+++ b/test/unit/migrations/settings/0001-migrate-blog-category-to-ids-test.js
@@ -1,0 +1,82 @@
+import { module, test } from "qunit";
+import migrate from "../../../../migrations/settings/0001-migrate-blog-category-to-ids";
+
+module(
+  "Blog Post Styling | Unit | Migrations | Settings | 0001-migrate-blog-category-to-ids",
+  function () {
+    test("migrates single slug to id", function (assert) {
+      const settings = new Map(Object.entries({ blog_category: "blog" }));
+      const helpers = { getCategoryIdBySlug: (slug) => (slug === "blog" ? 5 : null) };
+
+      const result = migrate(settings, helpers);
+
+      assert.strictEqual(result.get("blog_category"), "5");
+    });
+
+    test("migrates multiple comma-separated slugs to pipe-separated ids", function (assert) {
+      const settings = new Map(
+        Object.entries({ blog_category: "blog,tech-blog" })
+      );
+      const helpers = {
+        getCategoryIdBySlug(slug) {
+          const map = { blog: 5, "tech-blog": 12 };
+          return map[slug] || null;
+        },
+      };
+
+      const result = migrate(settings, helpers);
+
+      assert.strictEqual(result.get("blog_category"), "5|12");
+    });
+
+    test("filters out slugs that do not match any category", function (assert) {
+      const settings = new Map(
+        Object.entries({ blog_category: "blog,nonexistent,tech-blog" })
+      );
+      const helpers = {
+        getCategoryIdBySlug(slug) {
+          const map = { blog: 5, "tech-blog": 12 };
+          return map[slug] || null;
+        },
+      };
+
+      const result = migrate(settings, helpers);
+
+      assert.strictEqual(result.get("blog_category"), "5|12");
+    });
+
+    test("handles empty blog_category value", function (assert) {
+      const settings = new Map(Object.entries({ blog_category: "" }));
+      const helpers = { getCategoryIdBySlug: () => null };
+
+      const result = migrate(settings, helpers);
+
+      assert.strictEqual(result.get("blog_category"), "");
+    });
+
+    test("does nothing when blog_category is not set", function (assert) {
+      const settings = new Map();
+      const helpers = { getCategoryIdBySlug: () => null };
+
+      const result = migrate(settings, helpers);
+
+      assert.false(result.has("blog_category"));
+    });
+
+    test("trims whitespace around slugs", function (assert) {
+      const settings = new Map(
+        Object.entries({ blog_category: "blog , tech-blog" })
+      );
+      const helpers = {
+        getCategoryIdBySlug(slug) {
+          const map = { blog: 5, "tech-blog": 12 };
+          return map[slug] || null;
+        },
+      };
+
+      const result = migrate(settings, helpers);
+
+      assert.strictEqual(result.get("blog_category"), "5|12");
+    });
+  }
+);

--- a/test/unit/migrations/settings/0001-migrate-blog-category-to-ids-test.js
+++ b/test/unit/migrations/settings/0001-migrate-blog-category-to-ids-test.js
@@ -6,7 +6,9 @@ module(
   function () {
     test("migrates single slug to id", function (assert) {
       const settings = new Map(Object.entries({ blog_category: "blog" }));
-      const helpers = { getCategoryIdBySlug: (slug) => (slug === "blog" ? 5 : null) };
+      const helpers = {
+        getCategoryIdBySlug: (slug) => (slug === "blog" ? 5 : null),
+      };
 
       const result = migrate(settings, helpers);
 


### PR DESCRIPTION
Updates the `blog_category` setting from plain text comma-separated input to use the standard category selector.

This PR includes a migration that converts existing comma-separated slug values to `|`-separated category IDs, so existing installs don't lose their config.

Also depends on discourse/discourse#38816 which adds `getCategoryIdBySlug` to the theme migration helpers. Not using a compat file as we will be merging this after the version bump.

| Before | After |
|---|---|
| <img width="693" height="245" alt="Screenshot 2026-03-24 at 5 39 57 PM" src="https://github.com/user-attachments/assets/b1ae8c0f-3626-4772-a721-dca40fddcd71" /> | <img width="691" height="118" alt="Screenshot 2026-03-24 at 4 18 16 PM" src="https://github.com/user-attachments/assets/88061189-66cd-40ef-a5d9-17bc7f67e363" /> |
| | <img width="692" height="167" alt="Screenshot 2026-03-24 at 4 18 22 PM" src="https://github.com/user-attachments/assets/e8992068-89c0-458c-8d50-a1251753b4be" /> |