### PR TITLE
DEV: Move setting strings to locale file for translation

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,3 +1,30 @@
 en:
+  theme_metadata:
+    settings:
+      blog_category:
+        description: "Enter the category slug of your blog category as it appears in the url.
+          The slug is bold in the following example url:
+          https://community.example.org/c/<b>blog-posts</b>/3
+          <br><br>
+          Note: you may use more than one category slug by comma separating the
+          slug values like: <b>blog-one,blog-two</b> <br>
+          Be sure there are no spaces after the commas."
+      blog_tag:
+        description: "Topics will have blog styling applied when they have any of the tags included in this setting."
+      image_size:
+        description: "No image - hides the featured image.<br>Full width - image spans the full width of the content area.<br>Centered - image maintains its aspect ratio and centers within the content area."
+        choices:
+          "no image": "No image"
+          "full width": "Full width"
+          "centered": "Centered"
+      image_position:
+        description: "Choose where the featured image appears relative to the title. Only below-title will include a summary."
+        choices:
+          "above title": "Above title"
+          "below title": "Below title"
+      dropcap_enabled:
+        description: "Enable drop cap styling for the first letter of blog posts."
+      mobile_enabled:
+        description: "Enable blog post styling on mobile devices."
   blog_post_styling:
     comments_heading: Comments

--- a/settings.yml
+++ b/settings.yml
@@ -1,20 +1,10 @@
 blog_category:
   type: string
   default: ""
-  description:
-    en: "Enter the category slug of your blog category as it appears in the url.
-      The slug is bold in the following example url:
-      https://community.example.org/c/<b>blog-posts</b>/3
-      <br><br>
-      Note: you may use more than one category slug by comma separating the
-      slug values like: <b>blog-one,blog-two</b> <br>
-      Be sure there are no spaces after the commas."
 blog_tag:
   type: list
   list_type: tag
   default: ""
-  description:
-    en: "Topics will have blog styling applied when they have any of the tags included in this setting."
 image_size:
   type: enum
   default: "full width"
@@ -22,23 +12,15 @@ image_size:
     - no image
     - full width
     - centered
-  description:
-    en: "No image - hides the featured image.<br>Full width - image spans the full width of the content area.<br>Centered - image maintains its aspect ratio and centers within the content area."
 image_position:
   type: enum
   default: "above title"
   choices:
     - above title
     - below title
-  description:
-    en: "Choose where the featured image appears relative to the title. Only below-title will include a summary."
 dropcap_enabled:
   type: bool
   default: false
-  description:
-    en: "Enable drop cap styling for the first letter of blog posts."
 mobile_enabled:
   type: bool
   default: false
-  description:
-    en: "Enable blog post styling on mobile devices."


### PR DESCRIPTION
Moves setting descriptions and enum choice labels from inline `description.en` blocks in `settings.yml` into `locales/en.yml` under the `theme_metadata` key so they can be translated.